### PR TITLE
Relax Flask dependency to >=0.12.2,<2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup_requires = [
 ]
 
 install_requires = [
-    'Flask~=0.0,>=0.12.2',
+    'Flask>=0.12.2,<2',
     'bpython~=0.0,>=0.16',
     'click~=6.0,>=6.7',
 ]


### PR DESCRIPTION
I have tried using flask-shell-bpython with Flask 1.0 and it works. Assuming Flask uses Semver, relaxing to any version <2 seems safe.

Fixes #9 